### PR TITLE
Add Text.{Lexer,Parser}.Core to the list of installed modules

### DIFF
--- a/libs/contrib/contrib.ipkg
+++ b/libs/contrib/contrib.ipkg
@@ -8,4 +8,6 @@ modules = Syntax.WithProof,
           Text.Quantity,
           Control.Delayed,
           Text.Parser,
-          Text.Lexer
+          Text.Lexer,
+          Text.Parser.Core,
+          Text.Lexer.Core


### PR DESCRIPTION
On new installations, `idris2` runs on projects that use parsers/lexers would fail because the modules were not found.

On existing installations, the TTC files would not get updated when they change upstream.

This patch fixes this.