### PR TITLE
Fix ml_idris2_getString

### DIFF
--- a/support/malfunction/rts.c
+++ b/support/malfunction/rts.c
@@ -96,7 +96,7 @@ CAMLprim value ml_idris2_putStr(value s)
 CAMLprim value ml_idris2_getString(value sptr)
 {
 	CAMLparam1(sptr);
-	const char * result = idris2_getString((void *) sptr);
+	value result = caml_copy_string(idris2_getString((void *)sptr));
 	CAMLreturn((value) result);
 }
 


### PR DESCRIPTION
A quick fix for `ml_idris2_getString` to create a caml string instead of just returning the pointer